### PR TITLE
Republish v2.9.7 chart

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -6,6 +6,26 @@ entries:
         - name: Homepage
           url: https://www.kubecost.com
     apiVersion: v2
+    appVersion: 2.9.7
+    created: "2026-07-14T15:46:14.82012-07:00"
+    dependencies:
+    - alias: finopsagent
+      condition: finopsagent.enabled
+      name: finops-agent
+      repository: https://kubecost.github.io/finops-agent-chart
+      version: v1.0.20
+    description: Kubecost Helm chart - monitor your cloud costs!
+    digest: 1eac106c4e2739ca832432a9413a6edd74a85f3981a85beca2328ac584f3b36c
+    icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
+    name: cost-analyzer
+    urls:
+    - cost-analyzer-2.9.7.tgz
+    version: 2.9.7
+  - annotations:
+      artifacthub.io/links: |
+        - name: Homepage
+          url: https://www.kubecost.com
+    apiVersion: v2
     appVersion: 2.9.6
     created: "2026-07-14T15:46:14.814485-07:00"
     dependencies:


### PR DESCRIPTION
- Related to https://github.com/kubecost/cost-analyzer/pull/373
- Republishes `v2.9.7` Helm chart in the index
- Performed an image fix on `icr.io/kubecost/cost-model:2.9.7`. Tested against the v2.9.6 version of the helm chart. Will continue testing against the v2.9.7 helm chart once published.